### PR TITLE
Disable old base addresses

### DIFF
--- a/core/husarnet_config.h
+++ b/core/husarnet_config.h
@@ -3,7 +3,7 @@
 #include "ipaddress.h"
 #include <vector>
 
-#define HUSARNET_VERSION "2021.11.26.1"
+#define HUSARNET_VERSION "2021.12.07.1"
 
 __attribute__((unused)) static const InetAddress baseTcpAddresses[] = {
     {IpAddress::parse("188.165.23.196"), 443}, // ovh RBX (base-2)

--- a/core/husarnet_config.h
+++ b/core/husarnet_config.h
@@ -7,8 +7,8 @@
 
 __attribute__((unused)) static const InetAddress baseTcpAddresses[] = {
     {IpAddress::parse("188.165.23.196"), 443}, // ovh RBX (base-2)
-    {IpAddress::parse("147.135.76.110"), 443}, // ovh US (base-3)
-    {IpAddress::parse("51.254.25.193"), 443},  // fallback server
+    // {IpAddress::parse("147.135.76.110"), 443}, // ovh US (base-3)
+    // {IpAddress::parse("51.254.25.193"), 443},  // fallback server
 };
 
 __attribute__((unused)) static const char *dashboardUrl = "https://app.husarnet.com";

--- a/windows/installer/script.iss
+++ b/windows/installer/script.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Husarnet"
-#define HUSARNET_VERSION "2021.11.26.1"
+#define HUSARNET_VERSION "2021.12.07.1"
 #define MyAppPublisher "Husarnet Sp. z o.o."
 #define MyAppURL "https://husarnet.com"
 #define MyAppExeName "husarnet-gui.exe"


### PR DESCRIPTION
This part of the config is still used on Windows (and possibly ESP32). Hide the servers that are no longer in use while we transition to license based metadata fully.