### PR TITLE
fix: gcc13 compile error and memory error

### DIFF
--- a/core/api_server/server.cpp
+++ b/core/api_server/server.cpp
@@ -103,14 +103,14 @@ bool ApiServer::requireParams(
   return true;
 }
 
+template <typename iterable_InetAddress_t>
 std::list<std::string> stringifyInetAddressList(
-    const std::list<InetAddress>& source)
+    const iterable_InetAddress_t& source)
 {
-  std::list<std::string> stringified;
+  std::list<std::string> stringified{};
   std::transform(
-      source.cbegin(), source.cend(), stringified.begin(),
+      source.cbegin(), source.cend(), std::back_insert_iterator(stringified),
       [](const InetAddress element) { return element.str(); });
-
   return stringified;
 }
 

--- a/core/peer.cpp
+++ b/core/peer.cpp
@@ -41,24 +41,6 @@ IpAddress Peer::getIpAddress()
   return deviceIdToIpAddress(id);
 }
 
-std::list<InetAddress> Peer::getSourceAddresses()
-{
-  std::list<InetAddress> r;
-  for(auto addr : sourceAddresses) {
-    r.push_back(addr);
-  }
-  return r;
-}
-
-std::list<InetAddress> Peer::getTargetAddresses()
-{
-  std::list<InetAddress> r;
-  for(auto addr : targetAddresses) {
-    r.push_back(addr);
-  }
-  return r;
-}
-
 InetAddress Peer::getUsedTargetAddress()
 {
   return targetAddress;

--- a/core/peer.h
+++ b/core/peer.h
@@ -61,8 +61,12 @@ class Peer {
   DeviceId getDeviceId();
   IpAddress getIpAddress();
 
-  std::list<InetAddress> getSourceAddresses();
-  std::list<InetAddress> getTargetAddresses();
+  auto const& getSourceAddresses() {
+    return sourceAddresses;
+  }
+  auto const& getTargetAddresses() {
+    return targetAddresses;
+  }
   InetAddress getUsedTargetAddress();
   InetAddress getLinkLocalAddress();
 };

--- a/core/peer_flags.h
+++ b/core/peer_flags.h
@@ -3,6 +3,7 @@
 // License: specified in project_root/LICENSE.txt
 #pragma once
 #include <list>
+#include <cstdint>
 
 #include "enum.h"
 

--- a/core/ports/linux/port_interface.cpp
+++ b/core/ports/linux/port_interface.cpp
@@ -234,6 +234,11 @@ namespace Port {
   static bool writeFileDirect(const std::string& path, const std::string& data)
   {
     FILE* f = fopen(path.c_str(), "wb");
+    if(f == nullptr) {
+      throw std::runtime_error{
+          "Error: \"" + std::string{strerror(errno)} +
+          "\" while opening file: \"" + path + "\""};
+    }
     int ret = fwrite(data.data(), data.size(), 1, f);
     fsync(fileno(f));
     fclose(f);


### PR DESCRIPTION
got error of missing `cstdint` while compiling the daemon with gcc13 and libstdc++13 

When I tried to run it, it started with indexing nullptr, since the `/var/lib/husarnet` directory was nonexistent. I added runtime error with declarative error message instead of nullptr crash.

lastly, when std::transform is used the receiving container needs to allocate beforehand with [resize](https://en.cppreference.com/w/cpp/container/list/resize) or use back inserter iterator.
Furthermore, I generalized the code while debugging this crash, I don't see a reason to wrap the container when it can be used instead.

btw, great project, I hope I can learn to use it.