### PR TITLE
Dashboard API proxy in daemon

### DIFF
--- a/core/husarnet/api_server/dashboard_api_proxy.cpp
+++ b/core/husarnet/api_server/dashboard_api_proxy.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 Husarnet sp. z o.o.
+// Authors: listed in project_root/README.md
+// License: specified in project_root/LICENSE.txt
+#include "husarnet/api_server/dashboard_api_proxy.h"
+
+#include "husarnet/logging.h"
+
+bool DashboardApiProxy::isValid()
+{
+  return !apiAddress.empty();
+}
+
+void DashboardApiProxy::signAndForward(
+    const httplib::Request& req,
+    httplib::Response& res,
+    const std::string& path)
+{
+  nlohmann::json payload = nlohmann::json::parse(req.body, nullptr, false);
+  if(payload.is_discarded()) {
+    LOG_INFO("HTTP request body is not a valid JSON");
+    return;
+  }
+
+  auto pk = httplib::detail::base64_encode(identity->getPubkey());
+  auto sig = httplib::detail::base64_encode(identity->sign(payload.dump()));
+  nlohmann::json signedBody = {{"pk", pk}, {"sig", sig}, {"payload", payload}};
+
+  if(auto result =
+         httpClient.Post(path, signedBody.dump(), "application/json")) {
+    res.set_content(
+        result->body,
+        "application/json");  // Dashboard API always returns valid JSON
+  } else {
+    auto err = result.error();
+    LOG_ERROR(
+        "Can't contact Dashboard API: %s", httplib::to_string(err).c_str());
+  }
+}

--- a/core/husarnet/api_server/dashboard_api_proxy.cpp
+++ b/core/husarnet/api_server/dashboard_api_proxy.cpp
@@ -30,7 +30,8 @@ void DashboardApiProxy::signAndForward(
     return;
   }
 
-  // Note: always taking first address. Will need new logic at the point we want multiple addresses support
+  // Note: always taking first address. Will need new logic at the point we want
+  // multiple addresses support
   httplib::Client httpClient(dashboardApiAddresses[0].toString());
 
   nlohmann::json payloadJSON = nlohmann::json::parse(req.body, nullptr, false);

--- a/core/husarnet/api_server/dashboard_api_proxy.h
+++ b/core/husarnet/api_server/dashboard_api_proxy.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Husarnet sp. z o.o.
+// Authors: listed in project_root/README.md
+// License: specified in project_root/LICENSE.txt
+#pragma once
+#include <string>
+
+#include "husarnet/identity.h"
+
+#include "httplib.h"
+#include "nlohmann/json.hpp"
+
+class DashboardApiProxy {
+ private:
+  Identity* identity;
+  const std::string apiAddress;
+  httplib::Client httpClient;
+
+ public:
+  DashboardApiProxy(Identity* identityPtr, const std::string& addr)
+      : identity(identityPtr), apiAddress(addr), httpClient(addr)
+  {
+  }
+  bool isValid();
+  void signAndForward(
+      const httplib::Request& req,
+      httplib::Response& res,
+      const std::string& path);
+};

--- a/core/husarnet/api_server/dashboard_api_proxy.h
+++ b/core/husarnet/api_server/dashboard_api_proxy.h
@@ -16,7 +16,9 @@ class DashboardApiProxy {
   HusarnetManager* manager;
 
  public:
-  DashboardApiProxy(HusarnetManager* manager) : manager(manager) {}
+  DashboardApiProxy(HusarnetManager* manager) : manager(manager)
+  {
+  }
 
   void signAndForward(
       const httplib::Request& req,

--- a/core/husarnet/api_server/dashboard_api_proxy.h
+++ b/core/husarnet/api_server/dashboard_api_proxy.h
@@ -4,6 +4,8 @@
 #pragma once
 #include <string>
 
+#include <husarnet/husarnet_manager.h>
+
 #include "husarnet/identity.h"
 
 #include "httplib.h"
@@ -11,16 +13,11 @@
 
 class DashboardApiProxy {
  private:
-  Identity* identity;
-  const std::string apiAddress;
-  httplib::Client httpClient;
+  HusarnetManager* manager;
 
  public:
-  DashboardApiProxy(Identity* identityPtr, const std::string& addr)
-      : identity(identityPtr), apiAddress(addr), httpClient(addr)
-  {
-  }
-  bool isValid();
+  DashboardApiProxy(HusarnetManager* manager) : manager(manager) {}
+
   void signAndForward(
       const httplib::Request& req,
       httplib::Response& res,

--- a/core/husarnet/api_server/server.cpp
+++ b/core/husarnet/api_server/server.cpp
@@ -223,6 +223,10 @@ void ApiServer::runThread()
           LOG_WARNING(
               "Not forwarding the request, as proxy does not have valid "
               "Dashboard API address");
+          returnError(
+              req, res,
+              "claim request registered but dashboard API address is not "
+              "known");
         }
       });
 

--- a/core/husarnet/api_server/server.cpp
+++ b/core/husarnet/api_server/server.cpp
@@ -24,7 +24,7 @@ using namespace nlohmann;  // json
 
 ApiServer::ApiServer(HusarnetManager* manager) : manager(manager)
 {
-  manager->rotateApiSecret();
+  manager->rotateDaemonApiSecret();
 }
 
 void ApiServer::returnSuccess(
@@ -80,7 +80,7 @@ bool ApiServer::validateSecret(
     httplib::Response& res)
 {
   if(!req.has_param("secret") ||
-     req.get_param_value("secret") != manager->getApiSecret()) {
+     req.get_param_value("secret") != manager->getDaemonApiSecret()) {
     returnInvalidQuery(req, res, "invalid control secret");
     return false;
   }
@@ -347,27 +347,29 @@ void ApiServer::runThread()
 
   IpAddress bindAddress{};
 
-  if(manager->getApiInterface() != "") {
+  if(manager->getDaemonApiInterface() != "") {
     // Deduce bind address from the provided interface
-    bindAddress = manager->getApiInterfaceAddress();
+    bindAddress = manager->getDaemonApiInterfaceAddress();
     LOG_INFO(
         "Deducing bind address %s from the provided interface: %s",
-        bindAddress.toString().c_str(), manager->getApiInterface().c_str());
+        bindAddress.toString().c_str(),
+        manager->getDaemonApiInterface().c_str());
   } else {
     // Use provided/default bind address
-    bindAddress = manager->getApiAddress();
+    bindAddress = manager->getDaemonApiAddress();
   }
 
-  if(!svr.bind_to_port(bindAddress.toString().c_str(), manager->getApiPort())) {
+  if(!svr.bind_to_port(
+         bindAddress.toString().c_str(), manager->getDaemonApiPort())) {
     LOG_CRITICAL(
         "Unable to bind HTTP thread to port %s:%d. Exiting!",
-        bindAddress.toString().c_str(), manager->getApiPort());
+        bindAddress.toString().c_str(), manager->getDaemonApiPort());
     exit(1);
   } else {
     LOG_INFO(
         "HTTP thread bound to %s:%d. Will start handling the "
         "connections.",
-        bindAddress.toString().c_str(), manager->getApiPort());
+        bindAddress.toString().c_str(), manager->getDaemonApiPort());
   }
 
   cv.notify_all();

--- a/core/husarnet/api_server/server.cpp
+++ b/core/husarnet/api_server/server.cpp
@@ -217,17 +217,7 @@ void ApiServer::runThread()
           return;
         }
 
-        if(proxy->isValid()) {
-          proxy->signAndForward(req, res, "/device/rw/claim");
-        } else {
-          LOG_WARNING(
-              "Not forwarding the request, as proxy does not have valid "
-              "Dashboard API address");
-          returnError(
-              req, res,
-              "claim request registered but dashboard API address is not "
-              "known");
-        }
+        proxy->signAndForward(req, res, "/device/manage/claim");
       });
 
   svr.Post(

--- a/core/husarnet/api_server/server.h
+++ b/core/husarnet/api_server/server.h
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <string>
 
+#include "husarnet/api_server/dashboard_api_proxy.h"
+
 #include "httplib.h"
 #include "nlohmann/json.hpp"
 
@@ -20,6 +22,7 @@ namespace httplib {
 class ApiServer {
  private:
   HusarnetManager* manager;
+  DashboardApiProxy* proxy;
   std::mutex mutex;
   std::condition_variable cv;
 
@@ -48,7 +51,7 @@ class ApiServer {
       std::list<std::string> paramNames);
 
  public:
-  ApiServer(HusarnetManager* manager);
+  ApiServer(HusarnetManager* manager, DashboardApiProxy* proxy);
 
   void runThread();
   void waitStarted();

--- a/core/husarnet/husarnet_manager.cpp
+++ b/core/husarnet/husarnet_manager.cpp
@@ -331,6 +331,10 @@ std::vector<IpAddress> HusarnetManager::getBaseServerAddresses()
 {
   return license->getBaseServerAddresses();
 }
+std::vector<IpAddress> HusarnetManager::getDashboardApiAddresses()
+{
+  return license->getDashboardApiAddresses();
+}
 
 NgSocket* HusarnetManager::getNGSocket()
 {
@@ -479,10 +483,15 @@ void HusarnetManager::startWebsetup()
 void HusarnetManager::startHTTPServer()
 {
 #ifdef HTTP_CONTROL_API
-  auto server = new ApiServer(this);
+  std::string dashboardApiAddress{};
+  auto dashboardApiAddresses = getDashboardApiAddresses();
+  if(!dashboardApiAddresses.empty() && dashboardApiAddresses[0].isFC94()) {
+    dashboardApiAddress = dashboardApiAddresses[0].toString();
+  }
+  auto proxy = new DashboardApiProxy(getIdentity(), dashboardApiAddress);
+  auto server = new ApiServer(this, proxy);
 
   threadpool.push_back(new std::thread([=]() { server->runThread(); }));
-
   server->waitStarted();
 #endif
 }

--- a/core/husarnet/husarnet_manager.cpp
+++ b/core/husarnet/husarnet_manager.cpp
@@ -483,12 +483,7 @@ void HusarnetManager::startWebsetup()
 void HusarnetManager::startHTTPServer()
 {
 #ifdef HTTP_CONTROL_API
-  std::string dashboardApiAddress{};
-  auto dashboardApiAddresses = getDashboardApiAddresses();
-  if(!dashboardApiAddresses.empty() && dashboardApiAddresses[0].isFC94()) {
-    dashboardApiAddress = dashboardApiAddresses[0].toString();
-  }
-  auto proxy = new DashboardApiProxy(getIdentity(), dashboardApiAddress);
+  auto proxy = new DashboardApiProxy(this);
   auto server = new ApiServer(this, proxy);
 
   threadpool.push_back(new std::thread([=]() { server->runThread(); }));

--- a/core/husarnet/husarnet_manager.cpp
+++ b/core/husarnet/husarnet_manager.cpp
@@ -281,42 +281,42 @@ void HusarnetManager::setVerbosity(LogLevel level)
   globalLogLevel = level;
 }
 
-int HusarnetManager::getApiPort()
+int HusarnetManager::getDaemonApiPort()
 {
   return configStorage->getUserSettingInt(UserSetting::daemonApiPort);
 }
 
-IpAddress HusarnetManager::getApiAddress()
+IpAddress HusarnetManager::getDaemonApiAddress()
 {
   return configStorage->getUserSettingIp(UserSetting::daemonApiAddress);
 }
 
-std::string HusarnetManager::getApiInterface()
+std::string HusarnetManager::getDaemonApiInterface()
 {
   return configStorage->getUserSetting(UserSetting::daemonApiInterface);
 }
 
-IpAddress HusarnetManager::getApiInterfaceAddress()
+IpAddress HusarnetManager::getDaemonApiInterfaceAddress()
 {
-  return Port::getIpAddressFromInterfaceName(this->getApiInterface());
+  return Port::getIpAddressFromInterfaceName(this->getDaemonApiInterface());
 }
 
-std::string HusarnetManager::getApiSecret()
+std::string HusarnetManager::getDaemonApiSecret()
 {
   auto secret = Port::readApiSecret();
   if(secret.empty()) {
-    rotateApiSecret();
+    rotateDaemonApiSecret();
     secret = Port::readApiSecret();
   }
 
   return secret;
 }
 
-std::string HusarnetManager::rotateApiSecret()
+std::string HusarnetManager::rotateDaemonApiSecret()
 {
   this->getHooksManager()->withRw(
       [&]() { Port::writeApiSecret(generateRandomString(32)); });
-  return this->getApiSecret();
+  return this->getDaemonApiSecret();
 }
 
 std::string HusarnetManager::getDashboardFqdn()

--- a/core/husarnet/husarnet_manager.h
+++ b/core/husarnet/husarnet_manager.h
@@ -143,6 +143,7 @@ class HusarnetManager {
   std::string getDashboardFqdn();
   IpAddress getWebsetupAddress();
   std::vector<IpAddress> getBaseServerAddresses();
+  std::vector<IpAddress> getDashboardApiAddresses();
 
   NgSocket* getNGSocket();
   SecurityLayer* getSecurityLayer();

--- a/core/husarnet/husarnet_manager.h
+++ b/core/husarnet/husarnet_manager.h
@@ -133,12 +133,12 @@ class HusarnetManager {
   LogLevel getVerbosity();
   void setVerbosity(LogLevel level);
 
-  int getApiPort();
-  IpAddress getApiAddress();
-  std::string getApiInterface();
-  IpAddress getApiInterfaceAddress();
-  std::string getApiSecret();
-  std::string rotateApiSecret();
+  int getDaemonApiPort();
+  IpAddress getDaemonApiAddress();
+  std::string getDaemonApiInterface();
+  IpAddress getDaemonApiInterfaceAddress();
+  std::string getDaemonApiSecret();
+  std::string rotateDaemonApiSecret();
   // Copy of methods from License class
   std::string getDashboardFqdn();
   IpAddress getWebsetupAddress();

--- a/core/husarnet/licensing.cpp
+++ b/core/husarnet/licensing.cpp
@@ -186,7 +186,8 @@ License::License(std::string dashboardHostname)
   this->websetupAddress = IpAddress::parse(
       licenseJson[LICENSE_WEBSETUP_HOST_KEY].get<std::string>());
 
-  for(const auto& baseAddress : licenseJson[LICENSE_BASE_SERVER_ADDRESSES_KEY]) {
+  for(const auto& baseAddress :
+      licenseJson[LICENSE_BASE_SERVER_ADDRESSES_KEY]) {
     this->baseServerAddresses.emplace_back(
         IpAddress::parse(baseAddress.get<std::string>()));
   }

--- a/core/husarnet/licensing.h
+++ b/core/husarnet/licensing.h
@@ -18,11 +18,13 @@ class License {
   std::string dashboardFqdn;
   IpAddress websetupAddress;
   std::vector<IpAddress> baseServerAddresses;
+  std::vector<IpAddress> dashboardApiAddresses;
 
  public:
   License(std::string dashboardHostname);
   std::string getDashboardFqdn();
   IpAddress getWebsetupAddress();
   std::vector<IpAddress> getBaseServerAddresses();
+  std::vector<IpAddress> getDashboardApiAddresses();
   static bool validateDashboard(std::string dashboardHostname);
 };


### PR DESCRIPTION
Sign JSONs received with **daemon API** (`localhost:16216`) calls.
Forward signed JSONs to **dashboard API** (`api.husarnet.com`).

Dashboard API address is obtained from license.json (a field was added, and new signature field alongside old one - to maintain backward-compatibility)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint `/api/claim` for API interactions.
  
- **Improvements**
  - Enhanced API security with improved secret management.
  - Integrated `DashboardApiProxy` for better request handling.

- **Refactor**
  - Renamed API-related functions for better clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->