### PR TITLE
linux: add husarnet group

### DIFF
--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -2,10 +2,11 @@
 # Copyright (c) 2024 Husarnet sp. z o.o.
 # Authors: listed in project_root/README.md
 # License: specified in project_root/LICENSE.txt
-groupadd husarnet >> /dev/null 2>&1
+if ! grep -q "^husarnet:" /etc/group; then
+    groupadd husarnet
+fi
 chgrp husarnet /var/lib/husarnet -R
 chmod g+rwx /var/lib/husarnet -R
-sudo usermod -aG husarnet $SUDO_USER >> /dev/null 2>&1
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0
 

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -16,7 +16,7 @@ echo '**************************************************************'
 echo "To use Husarnet without sudo add your user to husarnet group:"
 echo "             sudo usermod -aG husarnet <username>            "
 echo "                             OR                              "
-echo "              sudo usermod -aG husarnet '$USER'              "
+echo "               sudo usermod -aG husarnet \$USER              "
 echo '**************************************************************'
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -10,7 +10,7 @@ if [ ! -d "/var/lib/husarnet" ]; then
   mkdir -p /var/lib/husarnet
 fi
 chgrp husarnet /var/lib/husarnet -R
-chmod g+rwx /var/lib/husarnet -R
+chmod g+rwx /var/lib/husarnet
 echo "To use Husarnet without sudo add your user to husarnet group:"
 echo "sudo usermod -aG husarnet $SUDO_USER"
 command -v pidof >/dev/null || exit 0

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -10,7 +10,8 @@ if [ ! -d "/var/lib/husarnet" ]; then
   mkdir -p /var/lib/husarnet
 fi
 chgrp husarnet /var/lib/husarnet -R
-chmod g+rwx /var/lib/husarnet
+find /var/lib/husarnet -type d -exec chmod 770 {} +
+find /var/lib/husarnet -type f -exec chmod 660 {} +
 echo "To use Husarnet without sudo add your user to husarnet group:"
 echo "sudo usermod -aG husarnet $SUDO_USER"
 command -v pidof >/dev/null || exit 0

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -11,6 +11,8 @@ if [ ! -d "/var/lib/husarnet" ]; then
 fi
 chgrp husarnet /var/lib/husarnet -R
 chmod g+rwx /var/lib/husarnet -R
+echo "To use Husarnet without sudo add your user to husarnet group:"
+echo "sudo usermod -aG husarnet $SUDO_USER"
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0
 

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -2,10 +2,10 @@
 # Copyright (c) 2024 Husarnet sp. z o.o.
 # Authors: listed in project_root/README.md
 # License: specified in project_root/LICENSE.txt
-groupadd husarnet 2>&1 >> /dev/null
+groupadd husarnet >> /dev/null 2>&1
 chgrp husarnet /var/lib/husarnet -R
 chmod g+rwx /var/lib/husarnet -R
-sudo usermod -aG husarnet $SUDO_USER 2>&1 >> /dev/null
+sudo usermod -aG husarnet $SUDO_USER >> /dev/null 2>&1
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0
 

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -2,8 +2,12 @@
 # Copyright (c) 2024 Husarnet sp. z o.o.
 # Authors: listed in project_root/README.md
 # License: specified in project_root/LICENSE.txt
+set -euo pipefail
 if ! grep -q "^husarnet:" /etc/group; then
     groupadd husarnet
+fi
+if [ ! -d "/var/lib/husarnet" ]; then
+  mkdir -p /var/lib/husarnet
 fi
 chgrp husarnet /var/lib/husarnet -R
 chmod g+rwx /var/lib/husarnet -R

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -12,8 +12,12 @@ fi
 chgrp husarnet /var/lib/husarnet -R
 find /var/lib/husarnet -type d -exec chmod 770 {} +
 find /var/lib/husarnet -type f -exec chmod 660 {} +
+echo '**************************************************************'
 echo "To use Husarnet without sudo add your user to husarnet group:"
-echo "sudo usermod -aG husarnet $SUDO_USER"
+echo "             sudo usermod -aG husarnet <username>            "
+echo "                             OR                              "
+echo "              sudo usermod -aG husarnet '$USER'              "
+echo '**************************************************************'
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0
 

--- a/platforms/linux/packaging/post-install-script.sh
+++ b/platforms/linux/packaging/post-install-script.sh
@@ -2,7 +2,10 @@
 # Copyright (c) 2024 Husarnet sp. z o.o.
 # Authors: listed in project_root/README.md
 # License: specified in project_root/LICENSE.txt
-
+groupadd husarnet 2>&1 >> /dev/null
+chgrp husarnet /var/lib/husarnet -R
+chmod g+rwx /var/lib/husarnet -R
+sudo usermod -aG husarnet $SUDO_USER 2>&1 >> /dev/null
 command -v pidof >/dev/null || exit 0
 command -v systemctl >/dev/null || exit 0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced user group management for the `husarnet` service during installation.
	- Created a `husarnet` user group and adjusted directory permissions for improved access.
	- Provided instructions for users on how to add themselves to the `husarnet` group for easier access without superuser privileges.
- **Improvements**
	- Enhanced the installation script for better error handling and robustness.
	- Added checks to ensure necessary directories and groups are created as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->